### PR TITLE
fix(parameters): use correct envar name in curl command

### DIFF
--- a/src/commands/notify_deployment.yml
+++ b/src/commands/notify_deployment.yml
@@ -32,7 +32,7 @@ parameters:
     description: |
       The name of environment variable containing
       CircleCI API Token. Required for all projects.
-    type: string
+    type: env_var_name
 steps:
   - jq/install:
       when: always

--- a/src/scripts/notify_deployment.sh
+++ b/src/scripts/notify_deployment.sh
@@ -44,10 +44,9 @@ generate_json_payload_deployment () {
 
 
 post_to_compass () {
-  TOKEN=$(eval echo "\$${TOKEN_NAME}") #TOKEN_NAME is just name, so we need to eval it as var.
   cat /tmp/compass-status.json
   HTTP_STATUS=$(curl \
-  -u "${TOKEN}:" \
+  -u "${!TOKEN_NAME}:" \
   -s -w "%{http_code}" -o /tmp/curl_response.txt \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \

--- a/src/scripts/notify_deployment.sh
+++ b/src/scripts/notify_deployment.sh
@@ -44,6 +44,7 @@ generate_json_payload_deployment () {
 
 
 post_to_compass () {
+  TOKEN=$(eval echo "\$${TOKEN_NAME}") #TOKEN_NAME is just name, so we need to eval it as var.
   cat /tmp/compass-status.json
   HTTP_STATUS=$(curl \
   -u "${TOKEN}:" \

--- a/src/scripts/notify_deployment.sh
+++ b/src/scripts/notify_deployment.sh
@@ -45,8 +45,9 @@ generate_json_payload_deployment () {
 
 post_to_compass () {
   cat /tmp/compass-status.json
+  eval TOKEN=\$$TOKEN_NAME #most portable way to use dynamic variable name
   HTTP_STATUS=$(curl \
-  -u "${!TOKEN_NAME}:" \
+  -u "${TOKEN}:" \
   -s -w "%{http_code}" -o /tmp/curl_response.txt \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \


### PR DESCRIPTION
Fixes #6 by changing envvar name used by curl to match one set in config.yml from parameter value (be it default or user provided)