### PR TITLE
fix: fix linting by making error mesage an echo command

### DIFF
--- a/src/scripts/notify_deployment.sh
+++ b/src/scripts/notify_deployment.sh
@@ -6,7 +6,7 @@ run () {
 
 verify_env_variables () {
   if [[ ! ${COMPASS_SHARED_SECRET} || ! ${COMPASS_WEBTRIGGER} ]]; then
-    "The environment variables required for the Compass orb aren’t configured. Please check if you’ve configured the integration correctly in the Compass UI."
+    echo "The environment variables required for the Compass orb aren’t configured. Please check if you’ve configured the integration correctly in the Compass UI."
     exit 0
   fi
 }


### PR DESCRIPTION
THis should fix the failing lint on last merge from #7 

```
In ./src/scripts/notify_deployment.sh line 9:
    "The environment variables required for the Compass orb aren’t configured. Please check if you’ve configured the integration correctly in the Compass UI."
    ^-- SC2288 (warning): This is interpreted as a command name ending with '.'. Double check syntax.
```
From: https://app.circleci.com/pipelines/github/atlassian-labs/Compass-Orb/12/workflows/fb128590-6518-4a2b-98a9-d248968a4d78/jobs/74?invite=true#step-102-79


This was unrelated to parameter change and seems the pipeline may not be fully operable based on brief history 😬  https://app.circleci.com/pipelines/github/atlassian-labs/Compass-Orb?branch=main
