### PR TITLE
Fixes #10 - respect environment parameter

### DIFF
--- a/src/commands/notify_deployment.yml
+++ b/src/commands/notify_deployment.yml
@@ -4,7 +4,7 @@ description: |
 
 parameters:
   environment:
-    default: ${CIRCLE_JOB}
+    default: "${CIRCLE_JOB}"
     description: |
       For deployments. Indicates the name of target environment.
       Default is the CircleCI Job Name.
@@ -48,6 +48,16 @@ steps:
         STATE_PATH: <<parameters.state_path>>
       command: <<include(scripts/build_success.sh)>>
       when: on_success
+  - run:
+      name: COMPASS - Set Environment Name
+      # `environment` is by default a variable name `${CIRCLE_JOB}`
+      # but unlike parameters, variables are not interpolated in config.yml 
+      # they must evaluate inside the container as part of a step
+      command: |
+        echo 'export ENVIRONMENT_NAME="<<parameters.environment>>"' >> $BASH_ENV
+        source $BASH_ENV
+        echo "Using displayName: $ENVIRONMENT_NAME"
+      when: always
   - run:
       name: Update status in Atlassian Compass
       environment:

--- a/src/scripts/notify_deployment.sh
+++ b/src/scripts/notify_deployment.sh
@@ -17,6 +17,7 @@ generate_json_payload_deployment () {
   --arg time_str "$(date +%s)" \
   --arg lastUpdated "${iso_time}" \
   --arg category "${ENVIRONMENT_TYPE^^}" \
+  --arg environmentName "${ENVIRONMENT_NAME}" \
   --arg environmentType "${ENVIRONMENT_TYPE}" \
   --arg workflowId "${CIRCLE_WORKFLOW_ID}" \
   --arg jobId "${CIRCLE_BUILD_NUM}" \
@@ -32,7 +33,7 @@ generate_json_payload_deployment () {
       {
           "environment": {
             "category": $category,
-            "displayName": $environmentType,
+            "displayName": $environmentName,
             "environmentId": $environmentType
           },
         "lastUpdated": $lastUpdated


### PR DESCRIPTION
This adds the necessary evaluation of the previously defined `environment` parameter, passing it to the underlying JSON payload sent to Compass.

**This change is a little different** since the `parameter.pipeline` value can be EITHER a variable or a string, we need to interpolate it inside the container so shell can determine value.  

The previous/current state noted in Issue #10 , the new fix can be tested using orb `eddiewebb/compass-fork-for-fixes@dev:7`  but sampels included below.

![Screen Shot 2022-09-16 at 9 43 18 AM](https://user-images.githubusercontent.com/5262154/190653592-e0f87c9e-e5c4-4ea2-a2d5-92173690c380.png)
![Screen Shot 2022-09-16 at 9 40 54 AM](https://user-images.githubusercontent.com/5262154/190653594-e4994cd3-c925-45be-9124-897499fb8354.png)
![Screen Shot 2022-09-16 at 9 40 38 AM](https://user-images.githubusercontent.com/5262154/190653597-875502b9-f606-41d6-a820-660122eb6cd7.png)
